### PR TITLE
feat: Update authentication scheme to ZITADEL_BASIC

### DIFF
--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -12,6 +12,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Text;
 using Infrastructure.Authentication;
 using Quartz;
+using Zitadel.Extensions;
 
 namespace Infrastructure;
 
@@ -77,30 +78,40 @@ public static class DependencyInjection
 
         services.AddSingleton(Options.Create(jwtSettings));
 
+        const string defaultScheme = "ZITADEL_BASIC";
+
         services
             .AddAuthentication(options =>
             {
-                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultSignInScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultSignOutScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
-                options.DefaultForbidScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultAuthenticateScheme = defaultScheme;
+                options.DefaultSignInScheme = defaultScheme;
+                options.DefaultSignOutScheme = defaultScheme;
+                options.DefaultChallengeScheme = defaultScheme;
+                options.DefaultForbidScheme = defaultScheme;
             })
-            .AddJwtBearer(options =>
-            {
-                options.TokenValidationParameters = new TokenValidationParameters
+            .AddZitadelIntrospection(
+                defaultScheme,
+                options =>
                 {
-                    ValidateActor = true,
-                    ValidateIssuer = true,
-                    ValidateAudience = true,
-                    ValidateLifetime = true,
-                    ValidateIssuerSigningKey = true,
-                    RequireExpirationTime = true,
-                    ValidIssuer = jwtSettings.Issuer,
-                    ValidAudience = jwtSettings.Audience,
-                    IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.Secret))
-                };
-            });
+                    options.Authority = "https://eloauth.com";
+                    options.ClientId = "170102032621961473@library";
+                    options.ClientSecret = "KNkKW8nx3rlEKOeHNUcPx80tZTP1uZTjJESfdA3kMEK7urhX3ChFukTMQrtjvG70";
+                });
+            //.AddJwtBearer(options =>
+            //{
+            //    options.TokenValidationParameters = new TokenValidationParameters
+            //    {
+            //        ValidateActor = true,
+            //        ValidateIssuer = true,
+            //        ValidateAudience = true,
+            //        ValidateLifetime = true,
+            //        ValidateIssuerSigningKey = true,
+            //        RequireExpirationTime = true,
+            //        ValidIssuer = jwtSettings.Issuer,
+            //        ValidAudience = jwtSettings.Audience,
+            //        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.Secret))
+            //    };
+            //});
 
         services.AddAuthorization();
 

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -94,8 +94,8 @@ public static class DependencyInjection
                 options =>
                 {
                     options.Authority = "https://eloauth.com";
-                    options.ClientId = "170102032621961473@library";
-                    options.ClientSecret = "KNkKW8nx3rlEKOeHNUcPx80tZTP1uZTjJESfdA3kMEK7urhX3ChFukTMQrtjvG70";
+                    options.ClientId = "ID";
+                    options.ClientSecret = "SECRET";
                 });
             //.AddJwtBearer(options =>
             //{


### PR DESCRIPTION
Changed the default authentication scheme to "ZITADEL_BASIC" for
sign-in, sign-out, challenge, and forbid. Added Zitadel
introspection for authentication with ZITADEL_BASIC scheme using
authority, client ID, and client secret. Removed previous JWT
Bearer configuration.